### PR TITLE
Added extra active collumn check

### DIFF
--- a/Search Display Templates/Table Layout with Sorting Templates (CSWP)/Item_List_Item.html
+++ b/Search Display Templates/Table Layout with Sorting Templates (CSWP)/Item_List_Item.html
@@ -95,6 +95,7 @@ _#-->
             // Show the properties that aren't empty
             for(var i = 1; i <= 10; i++) { 
                 var property = $getItemValue(ctx, String.format("Property {0}", i));
+				    if(property.managedPropertyName !== String.format("Property {0}", i)) {
             _#-->
                 <td class="ms-cellstyle ms-vb2">
             <!--#_
@@ -117,6 +118,7 @@ _#-->
             _#-->
                 </td>
             <!--#_
+			    }
             } 
             _#-->
         </tr>


### PR DESCRIPTION
In my experience the list_item template was always showing 10 columns
regardless whether there was no data in the column. 
I'm struggling with the way GitHub works. Some feedback whether the change was done properly / successfully would be nice.
